### PR TITLE
release/v1.5.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 2.7
   NewCops: enable
   SuggestExtensions: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2025-10-02
+
+### Added
+- **Ruby Compatibility**: Expanded Ruby version support
+  - Now compatible with Ruby 2.7.0 and above (previously required Ruby 3.0+)
+  - Added explicit OStruct dependency for better compatibility
+  - Improved cross-version compatibility for wider deployment scenarios
+
+### Changed
+- **Dependencies**: Updated dependency constraints for better semantic versioning
+  - Updated base64 and ostruct dependencies to use recommended version constraints
+  - Improved dependency resolution across different Ruby versions
+
 ## [1.5.0] - 2025-09-30
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,10 @@ PATH
   remote: .
   specs:
     lsql (1.5.0)
-      base64 (>= 0.1.0)
+      base64 (~> 0.1, >= 0.1.0)
       concurrent-ruby (>= 1.1, < 2.0)
       moneta (>= 1.0, < 2.0)
+      ostruct (~> 0.1, >= 0.1.0)
       redis (>= 4.0, < 6.0)
 
 GEM
@@ -19,6 +20,7 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     moneta (1.6.0)
+    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)

--- a/lib/lsql/version.rb
+++ b/lib/lsql/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lsql
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end

--- a/lsql.gemspec
+++ b/lsql.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
                      'with support for groups, parallel execution, and caching.'
   spec.homepage = 'https://github.com/egrif/lsql'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/egrif/lsql'
@@ -33,9 +33,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Runtime dependencies
-  spec.add_dependency 'base64', '>= 0.1.0'
+  spec.add_dependency 'base64', '~> 0.1', '>= 0.1.0'
   spec.add_dependency 'concurrent-ruby', '>= 1.1', '< 2.0'
   spec.add_dependency 'moneta', '>= 1.0', '< 2.0'
+  spec.add_dependency 'ostruct', '~> 0.1', '>= 0.1.0'
   spec.add_dependency 'redis', '>= 4.0', '< 6.0'
 
   # Development dependencies


### PR DESCRIPTION
- Expand Ruby version support from 3.0+ to 2.7.0+
- Add explicit ostruct dependency for better compatibility
- Update RuboCop target version to 2.7
- Improve dependency constraints with semantic versioning
- Enable wider deployment scenarios across Ruby versions
- Maintain full backward compatibility with existing functionality
